### PR TITLE
Group measurements within measure groups into separate types

### DIFF
--- a/lib/withings/measurement_group.rb
+++ b/lib/withings/measurement_group.rb
@@ -1,4 +1,31 @@
+require 'withings/measures'
+
 module Withings
   class MeasurementGroup < Base
+    # Types of body measurements collected by Withings devices and supported
+    # by this gem. See http://oauth.withings.com/api/doc#api-Measure-get_measure
+    # for details.
+    TYPES = {
+      1  => Withings::Measure::Weight,
+      4  => Withings::Measure::Height,
+      5  => Withings::Measure::FatFreeMass,
+      6  => Withings::Measure::FatRatio,
+      8  => Withings::Measure::FatMassWeight,
+      11 => Withings::Measure::Pulse
+    }
+
+    # Create a new instance with a collection of measurements of the appropriate
+    # Withings::Measure type.
+    #
+    # @param attrs [Hash]
+    # @return [Withings::MeasurementGroup]
+    def initialize(attrs = {})
+      super(attrs)
+      return if attrs['measures'].nil?
+      @measures = attrs['measures'].collect do |measurement|
+        klass = TYPES[measurement['type']]
+        klass.new(measurement) unless klass.nil?
+      end.reject { |obj| obj.nil? }
+    end
   end
 end

--- a/lib/withings/measures.rb
+++ b/lib/withings/measures.rb
@@ -1,0 +1,44 @@
+module Withings
+  class Measure < Base
+
+    # Create a new instance.
+    #
+    # The Withings API returns all values as integers with a unit which represents
+    # the power of 10 the value should be multiplied by to get the real value. For
+    # example, value=20 and unit=-1 should be 2.0.
+    #
+    # @param attrs [Hash]
+    # @return [Withings::Measure]
+    def initialize(attrs = {})
+      super(attrs)
+      @value = value / (10 ** unit.abs).to_f
+    end
+
+    #
+    # Different measurement types
+    #
+    
+    Weight = Class.new(self) do |cls|
+      # Return weight measurement in kilograms (default unit)
+      #
+      # @return [Float]
+      def in_kg
+        @value
+      end
+
+      # Return weight measurement in pounds
+      #
+      # @return [Float]
+      def in_lbs
+        @value * 2.20462
+      end
+    end
+    
+    Height = Class.new(self)
+    Pulse  = Class.new(self)
+
+    FatFreeMass   = Class.new(Weight)
+    FatMassWeight = Class.new(Weight)
+    FatRatio      = Class.new(self)
+  end
+end

--- a/lib/withings/measures.rb
+++ b/lib/withings/measures.rb
@@ -29,8 +29,8 @@ module Withings
       # Return weight measurement in pounds
       #
       # @return [Float]
-      def in_lbs
-        @value * 2.20462
+      def in_lb
+        (@value * 2.20462).round(3)
       end
     end
     

--- a/spec/weight_spec.rb
+++ b/spec/weight_spec.rb
@@ -1,0 +1,17 @@
+describe Withings::Measure::Weight do
+
+  let (:subject) { Withings::Measure::Weight.new(value: 87893, unit: -3) }
+
+  it 'should normalize the value based on the value and the unit' do
+    expect(subject.value).to eq(87.893)
+  end
+
+  it 'should return the value in kilograms' do
+    expect(subject.in_kg).to eq(87.893)
+  end
+
+  it 'should return the value in pounds' do
+    expect(subject.in_lb).to eq(193.771)
+  end
+    
+end


### PR DESCRIPTION
The Withings API returns body measurements in groups. Each group contains different measurements which can be a weight, pulse, etc.
